### PR TITLE
Changed links from osrf to open-rmf org

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir -p ros1_ws/src
         cd ros1_ws/src
-        git clone https://github.com/osrf/free_fleet
+        git clone https://github.com/open-rmf/free_fleet
         git clone https://github.com/eclipse-cyclonedds/cyclonedds
     - name: checkout
       uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
       run: |
         mkdir -p ros2_ws/src
         cd ros2_ws/src
-        git clone https://github.com/osrf/free_fleet
+        git clone https://github.com/open-rmf/free_fleet
         git clone https://github.com/open-rmf/rmf_internal_msgs
     - name: checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/osrf/free_fleet/workflows/build/badge.svg)
+![](https://github.com/open-rmf/free_fleet/workflows/build/badge.svg)
 
 # Free Fleet
 
@@ -70,7 +70,7 @@ Start a new ROS1 workspace, and pull in the necessary repositories,
 ```bash
 mkdir -p ~/client_ws/src
 cd ~/client_ws/src
-git clone https://github.com/osrf/free_fleet
+git clone https://github.com/open-rmf/free_fleet
 git clone https://github.com/eclipse-cyclonedds/cyclonedds
 ```
 
@@ -98,7 +98,7 @@ Start a new ROS2 workspace, and pull in the necessary repositories,
 ```bash
 mkdir -p ~/server_ws/src
 cd ~/server_ws/src
-git clone https://github.com/osrf/free_fleet
+git clone https://github.com/open-rmf/free_fleet
 git clone https://github.com/open-rmf/rmf_internal_msgs
 ```
 


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

Changing links in documentation and build test to use `open-rmf` instead of `osrf`.
