### PR TITLE
Started using ros2 parameter to define publish state frequency in server

### DIFF
--- a/free_fleet_server_ros2/src/ServerNode.cpp
+++ b/free_fleet_server_ros2/src/ServerNode.cpp
@@ -166,7 +166,8 @@ void ServerNode::start(Fields _fields)
           server_node_config.fleet_state_topic, 10);
 
   fleet_state_pub_timer = create_wall_timer(
-      200ms, std::bind(&ServerNode::publish_fleet_state, this),
+      std::chrono::seconds(1) / server_node_config.publish_state_frequency,
+      std::bind(&ServerNode::publish_fleet_state, this),
       fleet_state_pub_callback_group);
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Closes https://github.com/open-rmf/free_fleet/issues/85

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Uses ROS 2 parameterized `publish_state_frequency` for state publishing frequency, instead of hard coded value.
