### PR TITLE
Revert "Changed links from osrf to open-rmf org (#80)"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       run: |
         mkdir -p ros1_ws/src
         cd ros1_ws/src
-        git clone https://github.com/open-rmf/free_fleet
+        git clone https://github.com/osrf/free_fleet
         git clone https://github.com/eclipse-cyclonedds/cyclonedds
     - name: checkout
       uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
       run: |
         mkdir -p ros2_ws/src
         cd ros2_ws/src
-        git clone https://github.com/open-rmf/free_fleet
+        git clone https://github.com/osrf/free_fleet
         git clone https://github.com/open-rmf/rmf_internal_msgs
     - name: checkout
       uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://github.com/open-rmf/free_fleet/workflows/build/badge.svg)
+![](https://github.com/osrf/free_fleet/workflows/build/badge.svg)
 
 # Free Fleet
 
@@ -70,7 +70,7 @@ Start a new ROS1 workspace, and pull in the necessary repositories,
 ```bash
 mkdir -p ~/client_ws/src
 cd ~/client_ws/src
-git clone https://github.com/open-rmf/free_fleet
+git clone https://github.com/osrf/free_fleet
 git clone https://github.com/eclipse-cyclonedds/cyclonedds
 ```
 
@@ -98,7 +98,7 @@ Start a new ROS2 workspace, and pull in the necessary repositories,
 ```bash
 mkdir -p ~/server_ws/src
 cd ~/server_ws/src
-git clone https://github.com/open-rmf/free_fleet
+git clone https://github.com/osrf/free_fleet
 git clone https://github.com/open-rmf/rmf_internal_msgs
 ```
 


### PR DESCRIPTION
This reverts commit 3b3125c3ae64b7e0fc6fda7bfe2feb914a5b6d29.

This branch of stable release is the current version of freefleet of which decada robotics developments are based upon.
