### PR TITLE
Fix/clearer movebase errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 # vscode
 .vscode/
+
+# vim
+*.swp

--- a/free_fleet_client_ros1/src/ClientNode.cpp
+++ b/free_fleet_client_ros1/src/ClientNode.cpp
@@ -385,6 +385,7 @@ bool ClientNode::read_path_request()
               path_request.path[i].level_name,
               location_to_move_base_goal(path_request.path[i]),
               false,
+              0,
               ros::Time(
                   path_request.path[i].sec, path_request.path[i].nanosec)});
     }
@@ -420,6 +421,7 @@ bool ClientNode::read_destination_request()
             destination_request.destination.level_name,
             location_to_move_base_goal(destination_request.destination),
             false,
+            0,
             ros::Time(
                 destination_request.destination.sec, 
                 destination_request.destination.nanosec)});
@@ -509,7 +511,8 @@ void ClientNode::handle_requests()
         ROS_INFO("robot's navigation stack has aborted the current goal %d "
             "times, please check that there is nothing in the way of the "
             "robot, client will abort the current path request, and await "
-            "further requests.");
+            "further requests.",
+            goal_path.front().aborted_count);
         fields.move_base_client->cancelGoal();
         goal_path.clear();
         return;

--- a/free_fleet_client_ros1/src/ClientNode.hpp
+++ b/free_fleet_client_ros1/src/ClientNode.hpp
@@ -158,6 +158,7 @@ private:
     std::string level_name;
     move_base_msgs::MoveBaseGoal goal;
     bool sent = false;
+    uint32_t aborted_count = 0;
     ros::Time goal_end_time;
   };
 


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

Fixes https://github.com/open-rmf/free_fleet/issues/92.

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

* Keeps track of number failures/aborts the client receives from the navigation stack
* Handles `GoalState::ABORTED` and all other undesired states gracefully now, by retrying for a maximum number of 5 times.
* When retries exceeds 5 times, the entire navigation request will be terminated, and the client awaits either manual intervention or a new request.

### Test

* Follow instructions to build on `main` README, including the specific forks and branches of `robot_state_publisher` and `turtlebot3_simulations` to start the turtlebot world simulation.
* Give it a multi waypoint path request via server,

```bash
ros2 run ff_examples_ros2 send_path_request.py -f turtlebot3 -r tb3_0 -i UNIQUE_TASK_ID -p '[{"x": 1.725, "y": -0.39, "yaw": 0.0, "level_name": "B1"}, {"x": 1.737, "y": 0.951, "yaw": 1.57, "level_name": "B1"}, {"x": -0.616, "y": 1.852, "yaw": 3.14, "level_name": "B1"}, {"x": -0.626, "y": -1.972, "yaw": 4.71, "level_name": "B1"}]'
```

* Block the robot's path mercilessly, and wait for retries when the navigation stack aborts.

![image](https://user-images.githubusercontent.com/5383623/132626937-124c636f-9e62-48d3-b275-61dea33eb333.png)

The printouts should look something like this, when it aborts and tries again,
```bash
[ WARN] [1631164475.035547767, 1949.243000000]: Rotate recovery behavior started.
[ERROR] [1631164475.035651688, 1949.243000000]: Rotate recovery can't rotate in place because there is a potential collision. Cost: -1.00
[ INFO] [1631164475.136051509, 1949.343000000]: Got new plan
[ WARN] [1631164475.140834967, 1949.348000000]: DWA planner failed to produce path.
[ERROR] [1631164475.236090154, 1949.443000000]: Aborting because a valid control could not be found. Even after executing all recovery behaviors
[ INFO] [1631164475.335374478, 1949.542000000]: robot's navigation stack has aborted the current goal 2 times, client will trying again...
[ INFO] [1631164475.434817655, 1949.642000000]: sending next goal.
[ INFO] [1631164475.535611672, 1949.743000000]: Got new plan
[ WARN] [1631164475.539325824, 1949.746000000]: DWA planner failed to produce path.
```

The printouts should look something like this after it retries and fails for 5 times in a row,
```bash
[ WARN] [1631164828.697811637, 194.939000000]: DWA planner failed to produce path.
[ WARN] [1631164828.794001591, 195.036000000]: Rotate recovery behavior started.
[ERROR] [1631164828.794098687, 195.036000000]: Rotate recovery can't rotate in place because there is a potential collision. Cost: -1.00
[ INFO] [1631164828.893574894, 195.135000000]: Got new plan
[ WARN] [1631164828.897170407, 195.139000000]: DWA planner failed to produce path.
[ERROR] [1631164828.993381070, 195.235000000]: Aborting because a valid control could not be found. Even after executing all recovery behaviors
[ INFO] [1631164828.993924162, 195.235000000]: robot's navigation stack has aborted the current goal 5 times, please check that there is nothing in the way of the robot, client will abort the current path request, and await further requests.
```

A new path request can be sent over with a new unique ID, and it will start performing the new request.