### PR TITLE
Added repos files needed for ROS1 and ROS2 builds

### DIFF
--- a/ff_ros1.repos
+++ b/ff_ros1.repos
@@ -1,0 +1,9 @@
+repositories:
+  free_fleet:
+    type: git
+    url: https://github.com/open-rmf/free_fleet.git
+    version: main
+  cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: releases/0.7.x

--- a/ff_ros2.repos
+++ b/ff_ros2.repos
@@ -1,0 +1,9 @@
+repositories:
+  free_fleet:
+    type: git
+    url: https://github.com/open-rmf/free_fleet.git
+    version: main
+  rmf_internal_msgs:
+    type: git
+    url: https://github.com/open-rmf/rmf_internal_msgs.git
+    version: main


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

## CI

* Added `.repos` files required for both ROS1 or ROS2 builds