### PR TITLE
Added .repos file for non-ros packages to be used in CI

### DIFF
--- a/ff.repos
+++ b/ff.repos
@@ -1,0 +1,9 @@
+repositories:
+  free_fleet:
+    type: git
+    url: https://github.com/open-rmf/free_fleet.git
+    version: main
+  cyclonedds:
+    type: git
+    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+    version: releases/0.7.x


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

# CI

* Added a `.repos` file for non-ros related packages