### PR TITLE
For future new builds, cyclone should be tagged to 0.8.x

### DIFF
--- a/ff.repos
+++ b/ff.repos
@@ -6,4 +6,4 @@ repositories:
   cyclonedds:
     type: git
     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
-    version: releases/0.7.x
+    version: releases/0.8.x


### PR DESCRIPTION
Signed-off-by: Aaron Chong <aaronchongth@gmail.com>

# CI

* Tagging cyclone build to release 0.8.x for non-ros workflow