### PR TITLE
Fix compilation errors for ros2 client on Foxy

### DIFF
--- a/free_fleet_client_ros2/include/free_fleet/ros2/client_node.hpp
+++ b/free_fleet_client_ros2/include/free_fleet/ros2/client_node.hpp
@@ -93,7 +93,7 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::BatteryState>::SharedPtr  battery_percent_sub;
   Mutex battery_state_mutex;
   sensor_msgs::msg::BatteryState current_battery_state;
-  void battery_state_callback_fn(const sensor_msgs::msg::BatteryState& msg);
+  void battery_state_callback_fn(const sensor_msgs::msg::BatteryState::SharedPtr msg);
 
   // --------------------------------------------------------------------------
   // Robot pose handling

--- a/free_fleet_client_ros2/include/free_fleet/ros2/client_node_config.hpp
+++ b/free_fleet_client_ros2/include/free_fleet/ros2/client_node_config.hpp
@@ -32,10 +32,10 @@ namespace ros2
 struct ClientNodeConfig
 {
 
-  std::string fleet_name;
-  std::string robot_name;
-  std::string robot_model;
-  std::string level_name;
+  std::string fleet_name = "fleet_name";
+  std::string robot_name = "robot_name";
+  std::string robot_model = "robot_model";
+  std::string level_name = "level_name";
 
   std::string battery_state_topic = "/battery_state";
 

--- a/free_fleet_client_ros2/src/client_node.cpp
+++ b/free_fleet_client_ros2/src/client_node.cpp
@@ -19,6 +19,7 @@
 #include <exception>
 #include <thread>
 
+#include <rcl/time.h>
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
@@ -40,10 +41,10 @@ ClientNode::ClientNode(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(get_logger(), "Greetings from %s", get_name());
 
   // parameter declarations
-  declare_parameter<std::string>("fleet_name");
-  declare_parameter<std::string>("robot_name");
-  declare_parameter<std::string>("robot_model");
-  declare_parameter<std::string>("level_name");
+  declare_parameter("fleet_name", client_node_config.fleet_name);
+  declare_parameter("robot_name", client_node_config.robot_name);
+  declare_parameter("robot_model", client_node_config.robot_model);
+  declare_parameter("level_name", client_node_config.level_name);
   // defaults declared in header
   declare_parameter("battery_state_topic", client_node_config.battery_state_topic);
   declare_parameter("map_frame", client_node_config.map_frame);
@@ -175,10 +176,10 @@ void ClientNode::print_config()
 }
 
 void ClientNode::battery_state_callback_fn(
-  const sensor_msgs::msg::BatteryState & _msg)
+  const sensor_msgs::msg::BatteryState::SharedPtr _msg)
 {
   WriteLock battery_state_lock(battery_state_mutex);
-  current_battery_state = _msg;
+  current_battery_state = *_msg;
 }
 
 bool ClientNode::get_robot_pose()

--- a/free_fleet_client_ros2/src/tests/fake_action_server.cpp
+++ b/free_fleet_client_ros2/src/tests/fake_action_server.cpp
@@ -70,8 +70,6 @@ void execute(const std::shared_ptr<GoalHandleNavigateToPose> goal_handle)
     }
     // Update navigation time
     feedback->navigation_time = clock.now() - start;
-    feedback->estimated_time_remaining =
-      rclcpp::Duration::from_seconds(5) - feedback->navigation_time;
     // Publish feedback
     goal_handle->publish_feedback(feedback);
     RCLCPP_INFO(rclcpp::get_logger("execute_fn"), "Publish feedback");


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

Fixes #110, #111 

### Fix applied

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

Reverted back to default parameters when declaring each parameter to support Foxy builds. This results in a slight behavior change where you're now able to run the node without setting any parameters.

Added an additional fix where it was comparing or calculating with two timestamps with different clock types resulting in a crash. The solution correctly sets the `ROS_TIME` clock type when adding the location to the robot path.
