### PR TITLE
Fix installation of qt5 on the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Install all non-ROS prerequisite packages,
 
 ```bash
 sudo apt update && sudo apt install \
-  git wget qt5-default \
+  git wget qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
   python3-rosdep \
   python3-vcstool \
   python3-colcon-common-extensions \


### PR DESCRIPTION
Fix #125 
qt5-default package has been removed from Debian and Ubuntu repositories.
Modified README.md to install qt5 dependencies instead of the qt5-default package.

Signed-off-by: Esteban Martinena <orensbruli@gmail.com>
