### PR TITLE
Modify the condition for checking if the received message is valid

### DIFF
--- a/free_fleet/src/dds_utils/DDSSubscribeHandler.hpp
+++ b/free_fleet/src/dds_utils/DDSSubscribeHandler.hpp
@@ -116,7 +116,7 @@ public:
     {
       for (size_t i = 0; i < MaxSamplesNum; ++i)
       {
-        if (infos[i].valid_data)
+        if (infos[i].valid_data == true)
           msgs.push_back(std::shared_ptr<const Message>(shared_msgs[i]));
       }
       return msgs;


### PR DESCRIPTION
## Bug fix

### Fixed bug

Cyclone DDS has inconsistent behavior  on valid message data. As they do not solve the error, this change made the trick.
