### PR TITLE
Correcting colcon into catkin for ROS 1 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Source ROS 1 and build,
 ```bash
 cd ~/ff_ros1_ws
 source /opt/ros/noetic/setup.bash
-colcon build
+catkin build
 ```
 
 </br>


### PR DESCRIPTION
<!--
Correcting colcon into catkin for ROS 1
-->

## Bug fix

### Fixed bug

Corrected README.md line `colcon` into `catkin` for ROS 1.
