### PR TITLE
fix Crash node if easy_fleet creation fails

### DIFF
--- a/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
@@ -133,7 +133,10 @@ def main(argv=sys.argv):
         tf = compute_transforms(level, coords, node)
         fleet_config.add_robot_coordinates_transformation(level, tf)
 
+    # retrieves std::shared_ptr<EasyFullControl>
     fleet_handle = adapter.add_easy_fleet(fleet_config)
+    assert fleet_handle is not None, \
+    "An error was raised on attempt to create EasyFullControl Object"
 
     # Initialize zenoh
     zenoh_config = zenoh.Config.from_file(args.zenoh_config) \

--- a/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
@@ -133,10 +133,10 @@ def main(argv=sys.argv):
         tf = compute_transforms(level, coords, node)
         fleet_config.add_robot_coordinates_transformation(level, tf)
 
-    # retrieves std::shared_ptr<EasyFullControl>
     fleet_handle = adapter.add_easy_fleet(fleet_config)
     assert fleet_handle is not None, \
-    "An error was raised on attempt to create EasyFullControl Object"
+        "Failed to create EasyFullControl fleet, \
+        please verify that the fleet config is valid."
 
     # Initialize zenoh
     zenoh_config = zenoh.Config.from_file(args.zenoh_config) \


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

Upon creation of the EasyFullControl object the node may keep running even tho the returned pointer is null

### Fixed bug

If an invalid nav_graph file is passed to add_easy_fleet() function then it would return nullptr c.f. [code](https://github.com/open-rmf/rmf_ros2/blob/main/rmf_fleet_adapter/src/rmf_fleet_adapter/agv/Adapter.cpp#L247)

### Fix applied

add assert statement to exit the program if initialization fails
