### PR TITLE
Add robots to fleet during construction/initialization of robot adapters

### DIFF
--- a/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
@@ -229,24 +229,6 @@ def update_robot(robot: Nav1RobotAdapter | Nav2RobotAdapter):
         robot_pose,
         robot.get_battery_soc()
     )
-
-    if robot.update_handle is None:
-        robot.update_handle = robot.fleet_handle.add_robot(
-            robot.name,
-            state,
-            robot.configuration,
-            rmf_easy.RobotCallbacks(
-                lambda destination, execution: robot.navigate(
-                    destination, execution
-                ),
-                lambda activity: robot.stop(activity),
-                lambda category, description, execution: robot.execute_action(
-                    category, description, execution
-                )
-            )
-        )
-        return
-
     robot.update(state)
 
 

--- a/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
@@ -386,6 +386,14 @@ class Nav1RobotAdapter(RobotAdapter):
             init_robot_pose.result(),
             self.get_battery_soc()
         )
+
+        if self.fleet_handle is None:
+            self.node.get_logger().warn(
+                f'Fleet unavailable, skipping adding robot [{self.name}] '
+                'to fleet'
+            )
+            return
+
         self.update_handle = self.fleet_handle.add_robot(
             self.name,
             state,

--- a/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
@@ -358,6 +358,49 @@ class Nav1RobotAdapter(RobotAdapter):
             _battery_state_callback
         )
 
+        # Initialize robot
+        init_timeout_sec = self.robot_config_yaml.get('init_timeout_sec', 10)
+        self.node.get_logger().info(f'Initializing robot [{self.name}]...')
+        init_robot_pose = rclpy.Future()
+
+        def _get_init_pose():
+            robot_pose = self.get_pose()
+            if robot_pose is not None:
+                init_robot_pose.set_result(robot_pose)
+                init_robot_pose.done()
+
+        init_pose_timer = self.node.create_timer(1, _get_init_pose)
+        rclpy.spin_until_future_complete(
+            self.node, init_robot_pose, timeout_sec=init_timeout_sec
+        )
+
+        if init_robot_pose.result() is None:
+            error_message = \
+                f'Timeout trying to initialize robot [{self.name}]'
+            self.node.get_logger().error(error_message)
+            raise RuntimeError(error_message)
+
+        self.node.destroy_timer(init_pose_timer)
+        state = rmf_easy.RobotState(
+            self.get_map_name(),
+            init_robot_pose.result(),
+            self.get_battery_soc()
+        )
+        self.update_handle = self.fleet_handle.add_robot(
+            self.name,
+            state,
+            self.configuration,
+            rmf_easy.RobotCallbacks(
+                lambda destination, execution: self.navigate(
+                    destination, execution
+                ),
+                lambda activity: self.stop(activity),
+                lambda category, description, execution: self.execute_action(
+                    category, description, execution
+                )
+            )
+        )
+
     def get_battery_soc(self) -> float:
         return self.battery_soc
 

--- a/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
@@ -408,6 +408,13 @@ class Nav1RobotAdapter(RobotAdapter):
                 )
             )
         )
+        if not self.update_handle:
+            error_message = \
+                f'Failed to add robot [{self.name}] to fleet ' \
+                f'[{self.fleet_handle.more().fleet_name()}], this is most ' \
+                'likely due to a configuration error.'
+            self.node.get_logger().error(error_message)
+            raise RuntimeError(error_message)
 
     def get_battery_soc(self) -> float:
         return self.battery_soc

--- a/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
@@ -171,6 +171,14 @@ class Nav2RobotAdapter(RobotAdapter):
             init_robot_pose.result(),
             self.get_battery_soc()
         )
+
+        if self.fleet_handle is None:
+            self.node.get_logger().warn(
+                f'Fleet unavailable, skipping adding robot [{self.name}] '
+                'to fleet'
+            )
+            return
+
         self.update_handle = self.fleet_handle.add_robot(
             self.name,
             state,

--- a/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
@@ -175,7 +175,7 @@ class Nav2RobotAdapter(RobotAdapter):
         if self.fleet_handle is None:
             self.node.get_logger().warn(
                 f'Fleet unavailable, skipping adding robot [{self.name}] '
-                'to fleet'
+                'to fleet.'
             )
             return
 
@@ -193,6 +193,13 @@ class Nav2RobotAdapter(RobotAdapter):
                 )
             )
         )
+        if not self.update_handle:
+            error_message = \
+                f'Failed to add robot [{self.name}] to fleet ' \
+                f'[{self.fleet_handle.more().fleet_name()}], this is most ' \
+                'likely due to a configuration error.'
+            self.node.get_logger().error(error_message)
+            raise RuntimeError(error_message)
 
     def get_battery_soc(self) -> float:
         return self.battery_soc

--- a/free_fleet_adapter/tests/integration/test_nav1_robot_adapter.py
+++ b/free_fleet_adapter/tests/integration/test_nav1_robot_adapter.py
@@ -39,24 +39,28 @@ class TestNav1RobotAdapter(unittest.TestCase):
         cls.zenoh_session.close()
         rclpy.shutdown()
 
-    def test_non_existent_robot_pose(self):
+    def test_non_existent_robot(self):
         tf_buffer = Buffer()
 
-        robot_adapter = Nav1RobotAdapter(
-            name='missing_nav1_tb3',
-            configuration=None,
-            robot_config_yaml={
-                'initial_map': 'L1',
-            },
-            node=self.node,
-            zenoh_session=self.zenoh_session,
-            fleet_handle=None,
-            tf_buffer=tf_buffer
-        )
-
-        time.sleep(2)
-        transform = robot_adapter.get_pose()
-        assert transform is None
+        robot_found = False
+        try:
+            _ = Nav1RobotAdapter(
+                name='missing_nav1_tb3',
+                configuration=None,
+                robot_config_yaml={
+                    'initial_map': 'L1',
+                },
+                node=self.node,
+                zenoh_session=self.zenoh_session,
+                fleet_handle=None,
+                tf_buffer=tf_buffer
+            )
+            robot_found = True
+        except RuntimeError as e:
+            error_message = str(e)
+            assert 'Timeout trying to initialize robot [missing_nav1_tb3]' \
+                in error_message
+        assert not robot_found
 
     def test_robot_pose(self):
         tf_buffer = Buffer()
@@ -73,7 +77,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 
@@ -92,7 +95,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 
@@ -114,7 +116,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
         assert robot_adapter._is_navigation_done()
@@ -134,7 +135,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
         assert robot_adapter.execution is None
@@ -157,7 +157,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 
@@ -186,7 +185,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 
@@ -217,7 +215,6 @@ class TestNav1RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 

--- a/free_fleet_adapter/tests/integration/test_nav2_robot_adapter.py
+++ b/free_fleet_adapter/tests/integration/test_nav2_robot_adapter.py
@@ -39,24 +39,28 @@ class TestNav2RobotAdapter(unittest.TestCase):
         cls.zenoh_session.close()
         rclpy.shutdown()
 
-    def test_non_existent_robot_pose(self):
+    def test_non_existent_robot(self):
         tf_buffer = Buffer()
 
-        robot_adapter = Nav2RobotAdapter(
-            name='missing_nav2_tb3',
-            configuration=None,
-            robot_config_yaml={
-                'initial_map': 'L1',
-            },
-            node=self.node,
-            zenoh_session=self.zenoh_session,
-            fleet_handle=None,
-            tf_buffer=tf_buffer
-        )
-
-        time.sleep(2)
-        transform = robot_adapter.get_pose()
-        assert transform is None
+        robot_found = False
+        try:
+            _ = Nav2RobotAdapter(
+                name='missing_nav2_tb3',
+                configuration=None,
+                robot_config_yaml={
+                    'initial_map': 'L1',
+                },
+                node=self.node,
+                zenoh_session=self.zenoh_session,
+                fleet_handle=None,
+                tf_buffer=tf_buffer
+            )
+            robot_found = True
+        except RuntimeError as e:
+            error_message = str(e)
+            assert 'Timeout trying to initialize robot [missing_nav2_tb3]' \
+                in error_message
+        assert not robot_found
 
     def test_robot_pose(self):
         tf_buffer = Buffer()
@@ -73,7 +77,6 @@ class TestNav2RobotAdapter(unittest.TestCase):
             tf_buffer=tf_buffer
         )
 
-        time.sleep(2)
         transform = robot_adapter.get_pose()
         assert transform is not None
 

--- a/free_fleet_examples/config/fleet/nav1_tb3_simulation_fleet_config.yaml
+++ b/free_fleet_examples/config/fleet/nav1_tb3_simulation_fleet_config.yaml
@@ -38,6 +38,7 @@ rmf_fleet:
       responsive_wait: False # Should responsive wait be on/off for this specific robot? Overrides the fleet-wide setting.
       # For Nav1RobotAdapter
       navigation_stack: 1
+      init_timeout_sec: 5
       initial_map: "L1"
       maps:
         L1:

--- a/free_fleet_examples/config/fleet/nav2_tb3_simulation_fleet_config.yaml
+++ b/free_fleet_examples/config/fleet/nav2_tb3_simulation_fleet_config.yaml
@@ -38,6 +38,7 @@ rmf_fleet:
       responsive_wait: False # Should responsive wait be on/off for this specific robot? Overrides the fleet-wide setting.
       # For Nav2RobotAdapter
       navigation_stack: 2
+      init_timeout_sec: 5
       initial_map: "L1"
       maps:
         L1:

--- a/free_fleet_examples/config/fleet/nav2_unique_multi_tb3_simulation_fleet_config.yaml
+++ b/free_fleet_examples/config/fleet/nav2_unique_multi_tb3_simulation_fleet_config.yaml
@@ -38,6 +38,7 @@ rmf_fleet:
       responsive_wait: False # Should responsive wait be on/off for this specific robot? Overrides the fleet-wide setting.
       # For Nav2RobotAdapter
       navigation_stack: 2
+      init_timeout_sec: 5
       initial_map: "L1"
       maps:
         L1:
@@ -49,6 +50,7 @@ rmf_fleet:
       responsive_wait: False # Should responsive wait be on/off for this specific robot? Overrides the fleet-wide setting.
       # For Nav2RobotAdapter
       navigation_stack: 2
+      init_timeout_sec: 5
       initial_map: "L1"
       maps:
         L1:


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Initializes robot adapters during construction. This is required for initializing action plugins (in a subsequent PR).

### Considerations

I would ideally like to not repeat this piece of code, however some separation might be good if we ever have to handle different types of initialization depending on the navigation stack too.