### PR TITLE
Disable fail fast strategy for ci

### DIFF
--- a/.github/workflows/nav1-integration-tests.yaml
+++ b/.github/workflows/nav1-integration-tests.yaml
@@ -13,6 +13,7 @@ jobs:
     container:
       image: osrf/ros:${{ matrix.ros_distribution }}-desktop
     strategy:
+      fail-fast: false
       matrix:
         ros_distribution:
           - jazzy

--- a/.github/workflows/nav2-integration-tests.yaml
+++ b/.github/workflows/nav2-integration-tests.yaml
@@ -17,6 +17,7 @@ jobs:
     container:
       image: osrf/ros:${{ matrix.ros_distribution }}-desktop
     strategy:
+      fail-fast: false
       matrix:
         ros_distribution:
           - jazzy

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,6 +13,7 @@ jobs:
     name: Push minimal nav2 docker images to GitHub Packages
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ros_distribution: [jazzy]
     steps:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -12,6 +12,7 @@ jobs:
     container:
       image: osrf/ros:${{ matrix.ros_distribution }}-desktop
     strategy:
+      fail-fast: false
       matrix:
         ros_distribution:
           - jazzy


### PR DESCRIPTION
This will allow other matrix strategies to continue even when one of them fails, for example
```
strategy:
      matrix:
        ros_distribution:
          - jazzy
          - rolling
```
`jazzy` will be cancelled midway if `rolling` fails, while
```
strategy:
      fail-fast: false
      matrix:
        ros_distribution:
          - jazzy
          - rolling
```
each distribution will run till failure or pass on their own. This helps with further debugging