### PR TITLE
Fix multi tb3 launch file

### DIFF
--- a/free_fleet_examples/launch/nav2_unique_multi_tb3_simulation_fleet_adapter.launch.xml
+++ b/free_fleet_examples/launch/nav2_unique_multi_tb3_simulation_fleet_adapter.launch.xml
@@ -4,7 +4,7 @@
   <arg name="server_uri" default="" description="The URI of the api server to transmit state and task information."/>
 
   <group>
-    <include file="$(find-pkg-share free_fleet_adapter)/launch/fleet_adapter.launch.xml">
+    <include file="$(find-pkg-share free_fleet_adapter)/fleet_adapter.launch.xml">
       <arg name="use_sim_time" value="false"/>
       <arg name="nav_graph_file" value="$(find-pkg-share free_fleet_examples)/maps/turtlebot3_world/nav_graphs/0.yaml" />
       <arg name="config_file" value="$(find-pkg-share free_fleet_examples)/config/fleet/nav2_unique_multi_tb3_simulation_fleet_config.yaml"/>


### PR DESCRIPTION
## Bug fix

### Fixed bug

When following https://github.com/open-rmf/free_fleet?tab=readme-ov-file#nav2-multiple-turtlebot3-world, and running
```
ros2 launch free_fleet_examples nav2_unique_multi_tb3_simulation_fleet_adapter.launch.xml
```
it reports that the `fleet_adapter.launch.xml` does not exist

### Fix applied

Similar to other examples, I think this is the correct place 
https://github.com/open-rmf/free_fleet/blob/63b2e0d84f5e258a3168d7ffd6f09d30f191dcf6/free_fleet_examples/launch/nav2_tb3_simulation_fleet_adapter.launch.xml#L7

instead of launch/fleet_adapter.launch.xml
