### PR TITLE
Stop building ros1 images in nightly due to EOL

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,36 +50,6 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/minimal-zenoh-bridge-ros2dds:${{ matrix.ros_distribution }}-latest
           context: .github/docker/minimal-zenoh-bridge-ros2dds
 
-  build-minimal-nav1-docker-images:
-    name: Push minimal nav1 docker images to GitHub Packages
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ros_distribution: [noetic]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to docker
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push minimal-zenoh-bridge-ros1
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          build-args: |
-            ROS_DISTRO=${{ matrix.ros_distribution }}
-            ZENOH_BRIDGE_TAG=main
-            FREE_FLEET_BRANCH=main
-          tags: ghcr.io/${{ github.repository }}/minimal-zenoh-bridge-ros1:${{ matrix.ros_distribution }}-latest
-          context: .github/docker/minimal-zenoh-bridge-ros1
-
   nav1-integration-tests:
     needs: build-minimal-nav1-docker-images
     timeout-minutes: 10

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -68,24 +68,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push minimal-ros1-sim
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          build-args: |
-            ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/minimal-ros1-sim:${{ matrix.ros_distribution }}-latest
-          context: .github/docker/minimal-ros1-sim
-
-      - name: Build and push minimal-nav1-bringup
-        uses: docker/build-push-action@v5
-        with:
-          push: true
-          build-args: |
-            ROS_DISTRO=${{ matrix.ros_distribution }}
-          tags: ghcr.io/${{ github.repository }}/minimal-nav1-bringup:${{ matrix.ros_distribution }}-latest
-          context: .github/docker/minimal-nav1-bringup
-
       - name: Build and push minimal-zenoh-bridge-ros1
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,10 +1,9 @@
 name: nightly
 
-# on:
-#   schedule:
-#     # 2am SGT
-#     - cron: '0 18 * * *'
-on: push
+on:
+  schedule:
+    # 2am SGT
+    - cron: '0 18 * * *'
 defaults:
   run:
     shell: bash

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,9 +1,10 @@
 name: nightly
 
-on:
-  schedule:
-    # 2am SGT
-    - cron: '0 18 * * *'
+# on:
+#   schedule:
+#     # 2am SGT
+#     - cron: '0 18 * * *'
+on: push
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
## CI

Stop building ROS 1 sim and nav1 bringup docker images due to EOL. CI will just continue using past built images.