### PR TITLE
Add None check for plugin_config before processing plugins

### DIFF
--- a/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/fleet_adapter.py
@@ -128,19 +128,20 @@ def start_fleet_adapter(
         confirm.accept()
         return confirm
 
-    for plugin_name, plugin_data in plugin_config.items():
-        plugin_actions = plugin_data.get('actions')
-        if not plugin_actions:
-            node.get_logger().warn(
-                f'No action provided for plugin [{plugin_name}]! Fleet '
-                f'[{fleet_handle.fleet_name}] will not bid on tasks submitted '
-                f'with actions associated with this plugin unless the action '
-                f'is registered as a performable action for this fleet by '
-                f'the user.'
-            )
-            continue
-        for action in plugin_actions:
-            fleet_handle.more().add_performable_action(action, _accept_action)
+    if plugin_config is not None:
+        for plugin_name, plugin_data in plugin_config.items():
+            plugin_actions = plugin_data.get('actions')
+            if not plugin_actions:
+                node.get_logger().warn(
+                    f'No action provided for plugin [{plugin_name}]! Fleet '
+                    f'[{fleet_handle.fleet_name}] will not bid on tasks submitted '
+                    f'with actions associated with this plugin unless the action '
+                    f'is registered as a performable action for this fleet by '
+                    f'the user.'
+                )
+                continue
+            for action in plugin_actions:
+                fleet_handle.more().add_performable_action(action, _accept_action)
 
     robots = {}
     for robot_name in fleet_config.known_robots:

--- a/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
@@ -228,60 +228,61 @@ class Nav2RobotAdapter(RobotAdapter):
             return
 
         # Import and store plugin actions and action factories
-        for plugin_name, action_config in plugin_config.items():
-            try:
-                module = action_config['module']
-                plugin = importlib.import_module(module)
-                action_context = RobotActionContext(
-                    self.node,
-                    self.name,
-                    self.update_handle,
-                    self.fleet_config,
-                    action_config,
-                    self.get_battery_soc,
-                    self.get_map_name,
-                    self.get_pose
-                )
-                action_factory = plugin.ActionFactory(action_context)
-                for action in action_factory.actions:
-                    # Verify that this action is not duplicated across plugins
-                    target_plugin = self.action_to_plugin_name.get(action)
-                    if (target_plugin is not None and
-                            target_plugin != plugin_name):
-                        raise Exception(
-                            f'Action [{action}] is indicated to be supported '
-                            f'by multiple plugins: {target_plugin} and '
-                            f'{plugin_name}. The fleet adapter is unable to '
-                            f'select the intended plugin to be paired for '
-                            f'this action. Please ensure that action names '
-                            f'are not duplicated across supported plugins. '
-                            f'Unable to create ActionFactory for '
-                            f'{plugin_name}. Robot [{self.name}] will not be '
-                            f'able to perform actions associated with this '
-                            f'plugin.'
-                        )
-                    # Verify that this ActionFactory supports this action
-                    if not action_factory.supports_action(action):
-                        raise ValueError(
-                            f'The plugin config provided [{action}] as a '
-                            f'performable action, but it is not a supported '
-                            f'action in the {plugin_name} ActionFactory!'
-                        )
-                    self.action_to_plugin_name[action] = plugin_name
-                self.action_factories[plugin_name] = action_factory
-            except KeyError:
-                self.node.get_logger().info(
-                    f'Unable to create ActionFactory for {plugin_name}! '
-                    f'Configured plugin config is invalid. '
-                    f'Robot [{self.name}] will not be able to perform '
-                    f'actions associated with this plugin.'
-                )
-            except ImportError:
-                self.node.get_logger().info(
-                    f'Unable to import module for {plugin_name}! '
-                    f'Robot [{self.name}] will not be able to perform '
-                    f'actions associated with this plugin.'
-                )
+        if plugin_config is not None:
+            for plugin_name, action_config in plugin_config.items():
+                try:
+                    module = action_config['module']
+                    plugin = importlib.import_module(module)
+                    action_context = RobotActionContext(
+                        self.node,
+                        self.name,
+                        self.update_handle,
+                        self.fleet_config,
+                        action_config,
+                        self.get_battery_soc,
+                        self.get_map_name,
+                        self.get_pose
+                    )
+                    action_factory = plugin.ActionFactory(action_context)
+                    for action in action_factory.actions:
+                        # Verify that this action is not duplicated across plugins
+                        target_plugin = self.action_to_plugin_name.get(action)
+                        if (target_plugin is not None and
+                                target_plugin != plugin_name):
+                            raise Exception(
+                                f'Action [{action}] is indicated to be supported '
+                                f'by multiple plugins: {target_plugin} and '
+                                f'{plugin_name}. The fleet adapter is unable to '
+                                f'select the intended plugin to be paired for '
+                                f'this action. Please ensure that action names '
+                                f'are not duplicated across supported plugins. '
+                                f'Unable to create ActionFactory for '
+                                f'{plugin_name}. Robot [{self.name}] will not be '
+                                f'able to perform actions associated with this '
+                                f'plugin.'
+                            )
+                        # Verify that this ActionFactory supports this action
+                        if not action_factory.supports_action(action):
+                            raise ValueError(
+                                f'The plugin config provided [{action}] as a '
+                                f'performable action, but it is not a supported '
+                                f'action in the {plugin_name} ActionFactory!'
+                            )
+                        self.action_to_plugin_name[action] = plugin_name
+                    self.action_factories[plugin_name] = action_factory
+                except KeyError:
+                    self.node.get_logger().info(
+                        f'Unable to create ActionFactory for {plugin_name}! '
+                        f'Configured plugin config is invalid. '
+                        f'Robot [{self.name}] will not be able to perform '
+                        f'actions associated with this plugin.'
+                    )
+                except ImportError:
+                    self.node.get_logger().info(
+                        f'Unable to import module for {plugin_name}! '
+                        f'Robot [{self.name}] will not be able to perform '
+                        f'actions associated with this plugin.'
+                    )
 
     def get_battery_soc(self) -> float:
         return self.battery_soc


### PR DESCRIPTION

## Bug fix

### Fixed bug

Getting below error when running `ros2 launch free_fleet_examples nav2_unique_multi_tb3_simulation_fleet_adapter.launch.xml`:

```
[fleet_adapter.py-1]     for plugin_name, plugin_data in plugin_config.items():
[fleet_adapter.py-1] AttributeError: 'NoneType' object has no attribute 'items'
```
### Fix applied

Check `if plugin_config is not None` before processing plugins.

