### PR TITLE
Changing Hardcoded map_frame to variable

### DIFF
--- a/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
@@ -466,7 +466,7 @@ class Nav2RobotAdapter(RobotAdapter):
 
         time_now = self.node.get_clock().now().seconds_nanoseconds()
         stamp = Time(sec=time_now[0], nanosec=time_now[1])
-        header = Header(stamp=stamp, frame_id='map')
+        header = Header(stamp=stamp, frame_id=self.map_frame)
         position = GeometryMsgs_Point(x=x, y=y, z=z)
         quat = quaternion_from_euler(0, 0, yaw)
         orientation = GeometryMsgs_Quaternion(


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug
Fixes #208
<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied

changed the hardcoded map_frame to the `self.map_frame` resolved this issue
<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR. 
- [x] I did not use GenAI