### PR TITLE
Fix type hint for execution

### DIFF
--- a/free_fleet_adapter/free_fleet_adapter/action.py
+++ b/free_fleet_adapter/free_fleet_adapter/action.py
@@ -129,7 +129,7 @@ class RobotActionFactory(ABC):
         self,
         category: str,
         description: dict,
-        execution,
+        execution: rmf_easy.CommandExecution,
     ) -> RobotAction:
         # To be populated in the plugins
         ...

--- a/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav1_robot_adapter.py
@@ -650,7 +650,7 @@ class Nav1RobotAdapter(RobotAdapter):
         self,
         category: str,
         description: dict,
-        execution: ActivityIdentifier
+        execution: rmf_easy.CommandExecution
     ):
         # TODO(ac): change map using map_server load_map, and set initial
         # position again with /initialpose

--- a/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/nav2_robot_adapter.py
@@ -583,7 +583,7 @@ class Nav2RobotAdapter(RobotAdapter):
         self,
         category: str,
         description: dict,
-        execution: ActivityIdentifier
+        execution: rmf_easy.CommandExecution
     ):
         current_exec_handle = self.exec_handle
         if current_exec_handle is not None and \

--- a/free_fleet_adapter/free_fleet_adapter/robot_adapter.py
+++ b/free_fleet_adapter/free_fleet_adapter/robot_adapter.py
@@ -123,6 +123,6 @@ class RobotAdapter(ABC):
         self,
         category: str,
         description: dict,
-        execution: ActivityIdentifier
+        execution: rmf_easy.CommandExecution
     ):
         ...


### PR DESCRIPTION


## Bug fix

### Fixed bug
type hint for `execution` should be `rmf_easy.CommandExecution` instead of `ActivityIdentifier`
```
    @abstractmethod
    def execute_action(
        self,
        category: str,
        description: dict,
        execution: ActivityIdentifier
    ):
```
### Fix applied

update `execution: ActivityIdentifier` to `execution: rmf_easy.CommandExecution`



### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
